### PR TITLE
Fix incorrect vendor command paths

### DIFF
--- a/src/Console/Command.class.php
+++ b/src/Console/Command.class.php
@@ -12,6 +12,8 @@ class Command
 
     private int $verbosityLevel = 0;
 
+    protected string $vendorStubPath = '/vendor/superbition/Polyel-Framework/src/Console/stubs';
+
     public function __construct()
     {
 

--- a/src/Console/Commands/CreateCommandCommand.class.php
+++ b/src/Console/Commands/CreateCommandCommand.class.php
@@ -13,7 +13,7 @@ class CreateCommandCommand extends Command
         $commandName = $this->argument('command-name');
 
         $this->writeNewLine('Building Command stub source and destination file paths');
-        $sourceStub = APP_DIR . '/Polyel/src/Console/stubs/Command.stub';
+        $sourceStub = APP_DIR . "/$this->vendorStubPath/Command.stub";
         $distCommand = APP_DIR . "/app/Console/Commands/$commandName.php";
 
         $this->writeNewLine('Generating a new Command...');

--- a/src/Console/Commands/CreateControllerCommand.class.php
+++ b/src/Console/Commands/CreateControllerCommand.class.php
@@ -14,7 +14,7 @@ class CreateControllerCommand extends Command
         $controllerActionName = $this->option('--action');
 
         $this->writeNewLine('Building Controller stub source and destination file paths');
-        $sourceStub = APP_DIR . '/Polyel/src/Console/stubs/Controller.stub';
+        $sourceStub = APP_DIR . "/$this->vendorStubPath/Controller.stub";
         $distController = APP_DIR . "/app/Http/Controllers/$controllerName.php";
 
         $this->writeNewLine('Generating a new Controller...');

--- a/src/Console/Commands/CreateElementCommand.class.php
+++ b/src/Console/Commands/CreateElementCommand.class.php
@@ -14,7 +14,7 @@ class CreateElementCommand extends Command
         $elementTemplate = $this->option('--element-template');
 
         $this->writeNewLine('Building View Element stub source and destination file paths');
-        $sourceStub = APP_DIR . '/Polyel/src/Console/stubs/Element.stub';
+        $sourceStub = APP_DIR . "/$this->vendorStubPath/Element.stub";
         $distElement = APP_DIR . "/app/View/Elements/$elementName.php";
 
         $this->writeNewLine('Generating a new Element class...');

--- a/src/Console/Commands/CreateMiddlewareCommand.class.php
+++ b/src/Console/Commands/CreateMiddlewareCommand.class.php
@@ -13,7 +13,7 @@ class CreateMiddlewareCommand extends Command
         $middlewareName = $this->argument('middleware-name');
 
         $this->writeNewLine('Building Middleware stub source and destination file paths');
-        $sourceStub = APP_DIR . '/Polyel/src/Console/stubs/Middleware.stub';
+        $sourceStub = APP_DIR . "/$this->vendorStubPath/Middleware.stub";
         $distMiddleware = APP_DIR . "/app/Http/Middleware/$middlewareName.php";
 
         $this->writeNewLine('Generating a new Middleware class...');


### PR DESCRIPTION
Some commands were using the old file paths before the framework was split apart. Updated to use the proper vendor path for the framework.