### PR TITLE
Add support for a database session driver

### DIFF
--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -41,6 +41,15 @@ class DatabaseSessionDriver implements SessionDriver
         return true;
     }
 
+    public function saveSessionData($sessionID, $sessionData)
+    {
+        $sessionData = json_encode($sessionData, $this->jsonEncodeOptions, 1024);
+
+        DB::table('session')
+            ->where('id', '=', $sessionID)
+            ->update(['data' => $sessionData]);
+    }
+
     public function getSessionData($sessionID)
     {
         if($sessionData = DB::table('session')->where('id', '=', $sessionID)->first())

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -2,10 +2,42 @@
 
 namespace Polyel\Session\Drivers;
 
+use Polyel\Database\Facade\DB;
+
 class DatabaseSessionDriver implements SessionDriver
 {
     public function __construct()
     {
 
+    }
+
+    public function isValid($sessionID, $sessionData = false)
+    {
+        if(DB::table('session')->where('id', '=', $sessionID)->first() === null)
+        {
+            return false;
+        }
+
+        if($sessionData)
+        {
+            // Make sure the session ID from the cookie matches the session ID inside the session file
+            if(!array_key_exists('id', $sessionData) || $sessionData['id'] !== $sessionID)
+            {
+                // False when the session ID does not match the ID in the file, not just the name of the session file
+                return false;
+            }
+        }
+        else
+        {
+            // If the data passed in is null, it means the session file was empty or the data was missing
+            if($sessionData === null)
+            {
+                // False when no session data exists but the file does
+                return false;
+            }
+        }
+
+        // If nothing fails within this function, the session is deemed valid
+        return true;
     }
 }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -136,6 +136,7 @@ class DatabaseSessionDriver implements SessionDriver
                 ->delete();
         }
 
+        // TODO: Review this feature of destroying a cookie here
         if($destroyCookie)
         {
             $sessionCookie = [

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -78,6 +78,16 @@ class DatabaseSessionDriver implements SessionDriver
         });
     }
 
+    public function collisionCheckID($sessionID)
+    {
+        if(DB::table('session')->where('id', '=', $sessionID)->first())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     public function saveSessionData($sessionID, $sessionData)
     {
         $sessionData = json_encode($sessionData, $this->jsonEncodeOptions, 1024);

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Polyel\Session\Drivers;
+
+class DatabaseSessionDriver implements SessionDriver
+{
+    public function __construct()
+    {
+
+    }
+}

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -153,4 +153,16 @@ class DatabaseSessionDriver implements SessionDriver
             Cookie::queue(...$sessionCookie);
         }
     }
+
+    public function clear($sessionID)
+    {
+        $sessionData = $this->getSessionData($sessionID);
+
+        if(exists($sessionData))
+        {
+            $sessionData['data'] = null;
+
+            $this->saveSessionData($sessionID, $sessionData);
+        }
+    }
 }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -99,7 +99,7 @@ class DatabaseSessionDriver implements SessionDriver
 
     public function getSessionData($sessionID)
     {
-        if($sessionData = DB::table('session')->where('id', '=', $sessionID)->first())
+        if($sessionData = DB::table('session')->select('*')->where('id', '=', $sessionID)->first())
         {
             // TODO: Check if need to decode JSON here
 

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -108,11 +108,19 @@ class DatabaseSessionDriver implements SessionDriver
 
     public function saveSessionData($sessionID, $sessionData)
     {
-        $sessionData = json_encode($sessionData, $this->jsonEncodeOptions, 1024);
+        // Encode the data as JSON again before updating in the database
+        $sessionData['data'] = json_encode($sessionData['data'], $this->jsonEncodeOptions, 1024);
 
+        // Update the session row in the DB with new values and with the data column encoded as JSON
         DB::table('session')
             ->where('id', '=', $sessionID)
-            ->update(['data' => $sessionData]);
+            ->update([
+                'user_id' => $sessionData['user_id'],
+                'ip_addr' => $sessionData['ip_addr'],
+                'user_agent' => $sessionData['user_agent'],
+                'last_active' => $sessionData['last_active'],
+                'data' => $sessionData['data'],
+            ]);
     }
 
     public function getSessionData($sessionID)

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -6,6 +6,10 @@ use Polyel\Database\Facade\DB;
 
 class DatabaseSessionDriver implements SessionDriver
 {
+    private $jsonEncodeOptions = JSON_INVALID_UTF8_SUBSTITUTE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+
+    private $jsonDecodeOptions = JSON_INVALID_UTF8_SUBSTITUTE;
+
     public function __construct()
     {
 

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -84,7 +84,7 @@ class DatabaseSessionDriver implements SessionDriver
 
     public function collisionCheckID($sessionID)
     {
-        if(DB::table('session')->where('id', '=', $sessionID)->first())
+        if(DB::table('session')->where('id', '=', $sessionID)->first() === null)
         {
             return true;
         }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -40,4 +40,16 @@ class DatabaseSessionDriver implements SessionDriver
         // If nothing fails within this function, the session is deemed valid
         return true;
     }
+
+    public function getSessionData($sessionID)
+    {
+        if($sessionData = DB::table('session')->where('id', '=', $sessionID)->first())
+        {
+            // TODO: Check if need to decode JSON here
+
+            return $sessionData;
+        }
+
+        return null;
+    }
 }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -127,7 +127,8 @@ class DatabaseSessionDriver implements SessionDriver
     {
         if($sessionData = DB::table('session')->select('*')->where('id', '=', $sessionID)->first())
         {
-            // TODO: Check if need to decode JSON here
+            // Decode the session data from JSON to a PHP array
+            $sessionData['data'] = json_decode($sessionData['data'], true, 1024, $this->jsonDecodeOptions);
 
             return $sessionData;
         }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -122,4 +122,31 @@ class DatabaseSessionDriver implements SessionDriver
 
         return null;
     }
+
+    public function destroySession($sessionID, $destroyCookie = true)
+    {
+        if($this->isValid($sessionID))
+        {
+            DB::table('session')
+                ->where('id', '=', $sessionID)
+                ->delete();
+        }
+
+        if($destroyCookie)
+        {
+            $sessionCookie = [
+                $name = config('session.cookieName'),
+                $value = null,
+                $expire = -1,
+                $path = config('session.cookiePath'),
+                $domain = config('session.domain'),
+                $secure = config('session.secure'),
+                $httpOnly = config('session.httpOnly'),
+                $sameSite = 'None',
+            ];
+
+            // TODO: review this method of queuing a cookie
+            Cookie::queue(...$sessionCookie);
+        }
+    }
 }

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -41,6 +41,17 @@ class DatabaseSessionDriver implements SessionDriver
         return true;
     }
 
+    public function updateSession($sessionID, $request)
+    {
+        $sessionData = $this->getSessionData($sessionID);
+
+        $sessionData['ip_addr'] = $request->clientIP;
+        $sessionData['user_agent'] = $request->userAgent;
+        $sessionData['last_active'] = date("Y-m-d H:i:s");
+
+        $this->saveSessionData($sessionID, $sessionData);
+    }
+
     public function saveSessionData($sessionID, $sessionData)
     {
         $sessionData = json_encode($sessionData, $this->jsonEncodeOptions, 1024);

--- a/src/Session/Drivers/DatabaseSessionDriver.class.php
+++ b/src/Session/Drivers/DatabaseSessionDriver.class.php
@@ -88,6 +88,20 @@ class DatabaseSessionDriver implements SessionDriver
         return false;
     }
 
+    public function createNewSession($sessionID, $request)
+    {
+        $sessionData = [
+            'id' => $sessionID,
+            'user_id' => null,
+            'ip_addr' => $request->clientIP,
+            'user_agent' => $request->userAgent,
+            'last_active' => date("Y-m-d H:i:s"),
+            'data' => '{}',
+        ];
+
+        DB::table('session')->insert($sessionData);
+    }
+
     public function saveSessionData($sessionID, $sessionData)
     {
         $sessionData = json_encode($sessionData, $this->jsonEncodeOptions, 1024);

--- a/src/Session/Drivers/FileSessionDriver.class.php
+++ b/src/Session/Drivers/FileSessionDriver.class.php
@@ -144,6 +144,7 @@ class FileSessionDriver implements SessionDriver
             unlink(realpath($this->sessionFileStorage . $sessionID));
         }
 
+        // TODO: Review this feature of destroying a cookie here
         if($destroyCookie)
         {
             $sessionCookie = [
@@ -157,6 +158,7 @@ class FileSessionDriver implements SessionDriver
                 $sameSite = 'None',
             ];
 
+            // TODO: review this method of queuing a cookie
             Cookie::queue(...$sessionCookie);
         }
     }

--- a/src/Session/SessionManager.class.php
+++ b/src/Session/SessionManager.class.php
@@ -84,7 +84,12 @@ class SessionManager
 
     public function regenerateSession($request, $response)
     {
-        $prefix = config('session.prefix');
+        $prefix = null;
+        if($this->driverType === 'file')
+        {
+            // The session prefix is only used when using the file session driver
+            $prefix = config('session.prefix');
+        }
 
         do {
 

--- a/src/Session/SessionManager.class.php
+++ b/src/Session/SessionManager.class.php
@@ -10,6 +10,8 @@ class SessionManager
 {
     private $driver;
 
+    private string $driverType;
+
     private $availableDrivers;
 
     private $gcStarted = false;
@@ -26,6 +28,9 @@ class SessionManager
     {
         if(array_key_exists($driver, $this->availableDrivers))
         {
+            // Save the type of driver that is going to be used
+            $this->driverType = $driver;
+
             $driver = $this->availableDrivers[$driver];
             $this->driver = Polyel::resolveClass($driver);
         }

--- a/src/Session/SessionManager.class.php
+++ b/src/Session/SessionManager.class.php
@@ -17,7 +17,8 @@ class SessionManager
     public function __construct()
     {
         $this->availableDrivers = [
-          'file' => Polyel\Session\Drivers\FileSessionDriver::class,
+            'file' => Polyel\Session\Drivers\FileSessionDriver::class,
+            'database' => Polyel\Session\Drivers\DatabaseSessionDriver::class,
         ];
     }
 


### PR DESCRIPTION
Add support for using a MySQL database as a session storage system.

Better for performance and scaling.

Requires the use of a new default table called `session` which holds all the session data.

The actual column which holds the dynamic session data is a JSON column.